### PR TITLE
Travis fix

### DIFF
--- a/.rosinstall
+++ b/.rosinstall
@@ -1,0 +1,4 @@
+- git:
+    local-name: segway_v3
+    uri: https://github.com/utexas-bwi/segway_v3.git
+    version: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ install:
   - sudo apt-get install -qq -y python-rosdep
   - sudo rosdep init
   - rosdep update
+  - sudo apt-get install ros-indigo-moveit-*
   # Use rosdep to install all dependencies (including ROS itself)
   - rosdep install --from-paths .. --ignore-src --rosdistro $CI_ROS_DISTRO
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ env:
 # Install system dependencies, namely a very barebones ROS setup.
 before_install:
   - sudo sh -c "echo \"deb http://packages.ros.org/ros/ubuntu $ROS_CI_DESKTOP main\" > /etc/apt/sources.list.d/ros-latest.list"
+  - git clone https://github.com/StanleyInnovation/segway_v3
   - wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
   - sudo apt-get update -qq
   - sudo apt-get install -y python-catkin-pkg python-rosdep python-wstool ros-$ROS_DISTRO-catkin

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq -y python-rosdep
   - sudo rosdep init
+  - sudo apt-get install ros-indigo-catkin-pkg
   - rosdep update
   # Use rosdep to install all dependencies (including ROS itself)
   - rosdep install --from-paths ./ -i -y --rosdistro $CI_ROS_DISTRO

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
   - sudo rosdep init
   - rosdep update
   # Use rosdep to install all dependencies (including ROS itself)
-  - rosdep install --from-paths .. --ignore-src --rosdistro $CI_ROS_DISTRO
+  - rosdep install --from-paths ./ -i -y --rosdistro $CI_ROS_DISTRO
 script:
   - source /opt/ros/$CI_ROS_DISTRO/setup.bash
   - mkdir -p $CATKIN_WS_SRC

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ env:
 
 # Install system dependencies, namely a very barebones ROS setup.
 before_install:
+  - sudo apt-get install python-catkin-pkg
   - sudo sh -c "echo \"deb http://packages.ros.org/ros/ubuntu $ROS_CI_DESKTOP main\" > /etc/apt/sources.list.d/ros-latest.list"
   - wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
   - sudo apt-get update -qq

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,18 @@
-# Author: Felix Duvallet <felixd@gmail.com>
-
-# NOTE: The build lifecycle on Travis.ci is something like this:
-#    before_install
-#    install
-#    before_script
-#    script
-#    after_success or after_failure
-#    after_script
-#    OPTIONAL before_deploy
-#    OPTIONAL deploy
-#    OPTIONAL after_deploy
+# Template author: Felix Duvallet <felixd@gmail.com>
 
 ################################################################################
 
 # Use ubuntu trusty (14.04) with sudo privileges.
 dist: trusty
 sudo: required
+# Use depreciated env due to python conflicts
 group: deprecated-2017Q3
 language:
   - generic
 cache:
   - apt
 
-# Configuration variables. All variables are global now, but this can be used to
-# trigger a build matrix for different ROS distributions if desired.
+# Configuration variables. 
 env:
   global:
     - ROS_DISTRO=indigo
@@ -33,9 +22,6 @@ env:
     - CATKIN_OPTIONS=$CI_SOURCE_PATH/catkin.options
     - ROS_PARALLEL_JOBS='-j8 -l6'
 
-################################################################################
-
-# Install system dependencies, namely a very barebones ROS setup.
 before_install:
   - sudo sh -c "echo \"deb http://packages.ros.org/ros/ubuntu $ROS_CI_DESKTOP main\" > /etc/apt/sources.list.d/ros-latest.list"
   - git clone https://github.com/StanleyInnovation/segway_v3
@@ -43,17 +29,13 @@ before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -y python-catkin-pkg python-rosdep python-wstool ros-$ROS_DISTRO-catkin
   - source /opt/ros/$ROS_DISTRO/setup.bash
-  # Prepare rosdep to install dependencies.
   - sudo rosdep init
   - rosdep update
 
-# Create a catkin workspace with the package under integration.
 install:
   - mkdir -p ~/catkin_ws/src
   - cd ~/catkin_ws/src
   - catkin_init_workspace
-  # Create the devel/setup.bash (run catkin_make with an empty workspace) and
-  # source it to set the path variables.
   - cd ~/catkin_ws
   - catkin_make
   - source devel/setup.bash
@@ -73,18 +55,9 @@ before_script:
   - cd ~/catkin_ws
   - rosdep install -y --from-paths src --ignore-src --rosdistro $ROS_DISTRO
 
-# Compile and test (mark the build as failed if any step fails). If the
-# CATKIN_OPTIONS file exists, use it as an argument to catkin_make, for example
-# to blacklist certain packages.
-#
-# NOTE on testing: `catkin_make run_tests` will show the output of the tests
-# (gtest, nosetest, etc..) but always returns 0 (success) even if a test
-# fails. Running `catkin_test_results` aggregates all the results and returns
-# non-zero when a test fails (which notifies Travis the build failed).
 script:
   - source /opt/ros/$ROS_DISTRO/setup.bash
   - cd ~/catkin_ws
   - catkin_make $( [ -f $CATKIN_OPTIONS ] && cat $CATKIN_OPTIONS )
-  # Run the tests, ensuring the path is set correctly.
   - source devel/setup.bash
   - catkin_make run_tests && catkin_test_results

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ env:
     - CI_ROS_DISTRO="indigo"
 before_install:
   - git clone https://github.com/StanleyInnovation/segway_v3
-  - git clone https://github.com/ros-planning/moveit.git
   - git clone https://github.com/Kinovarobotics/kinova-ros.git
 install:
   - sudo sh -c 'echo "deb http://packages.ros.org/ros-shadow-fixed/ubuntu trusty main" > /etc/apt/sources.list.d/ros-latest.list'
@@ -18,6 +17,7 @@ install:
   - sudo apt-get install -qq -y python-rosdep
   - sudo rosdep init
   - rosdep update
+  - sudo apt-get install ros-indigo-moveit
   # Use rosdep to install all dependencies (including ROS itself)
   - rosdep install --from-paths .. --ignore-src --rosdistro $CI_ROS_DISTRO
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@
 # Use ubuntu trusty (14.04) with sudo privileges.
 dist: trusty
 sudo: required
+group: deprecated-2017Q3
 language:
   - generic
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ install:
   - sudo apt-get install -qq -y python-rosdep
   - sudo rosdep init
   - rosdep update
+  - sudo apt-get install ros-indigo-moveit-ros-planning-interface
+  - sudo apt-get install ros-indigo-moveit-ros-warehouse
   # Use rosdep to install all dependencies (including ROS itself)
   - rosdep install --from-paths .. --ignore-src --rosdistro $CI_ROS_DISTRO
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
   - sudo apt-get install -qq -y python-rosdep
   - sudo rosdep init
   - rosdep update
-  - sudo apt-get install ros-indigo-moveit
+  - sudo apt-get install ros-indigo-moveit-full
   # Use rosdep to install all dependencies (including ROS itself)
   - rosdep install --from-paths .. --ignore-src --rosdistro $CI_ROS_DISTRO
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,32 +1,88 @@
-sudo: required
+# Author: Felix Duvallet <felixd@gmail.com>
+
+# NOTE: The build lifecycle on Travis.ci is something like this:
+#    before_install
+#    install
+#    before_script
+#    script
+#    after_success or after_failure
+#    after_script
+#    OPTIONAL before_deploy
+#    OPTIONAL deploy
+#    OPTIONAL after_deploy
+
+################################################################################
+
+# Use ubuntu trusty (14.04) with sudo privileges.
 dist: trusty
-language: generic
+sudo: required
+language:
+  - generic
+cache:
+  - apt
+
+# Configuration variables. All variables are global now, but this can be used to
+# trigger a build matrix for different ROS distributions if desired.
 env:
   global:
-    - CATKIN_WS=~/catkin_ws
-    - CATKIN_WS_SRC=${CATKIN_WS}/src
-  matrix:
-    - CI_ROS_DISTRO="indigo"
+    - ROS_DISTRO=indigo
+    - ROS_CI_DESKTOP="`lsb_release -cs`"  # e.g. [precise|trusty|...]
+    - CI_SOURCE_PATH=$(pwd)
+    - ROSINSTALL_FILE=$CI_SOURCE_PATH/dependencies.rosinstall
+    - CATKIN_OPTIONS=$CI_SOURCE_PATH/catkin.options
+    - ROS_PARALLEL_JOBS='-j8 -l6'
+
+################################################################################
+
+# Install system dependencies, namely a very barebones ROS setup.
 before_install:
-  - git clone https://github.com/StanleyInnovation/segway_v3
-install:
-  - sudo sh -c 'echo "deb http://packages.ros.org/ros-shadow-fixed/ubuntu trusty main" > /etc/apt/sources.list.d/ros-latest.list'
+  - sudo sh -c "echo \"deb http://packages.ros.org/ros/ubuntu $ROS_CI_DESKTOP main\" > /etc/apt/sources.list.d/ros-latest.list"
   - wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
   - sudo apt-get update -qq
-  - sudo apt-get install -qq -y python-rosdep
+  - sudo apt-get install -y python-catkin-pkg python-rosdep python-wstool ros-$ROS_DISTRO-catkin
+  - source /opt/ros/$ROS_DISTRO/setup.bash
+  # Prepare rosdep to install dependencies.
   - sudo rosdep init
-  - sudo apt-get install ros-indigo-catkin-pkg
   - rosdep update
-  # Use rosdep to install all dependencies (including ROS itself)
-  - rosdep install --from-paths ./ -i -y --rosdistro $CI_ROS_DISTRO
+
+# Create a catkin workspace with the package under integration.
+install:
+  - mkdir -p ~/catkin_ws/src
+  - cd ~/catkin_ws/src
+  - catkin_init_workspace
+  # Create the devel/setup.bash (run catkin_make with an empty workspace) and
+  # source it to set the path variables.
+  - cd ~/catkin_ws
+  - catkin_make
+  - source devel/setup.bash
+  # Add the package under integration to the workspace using a symlink.
+  - cd ~/catkin_ws/src
+  - ln -s $CI_SOURCE_PATH .
+
+# Install all dependencies, using wstool first and rosdep second.
+# wstool looks for a ROSINSTALL_FILE defined in the environment variables.
+before_script:
+  # source dependencies: install using wstool.
+  - cd ~/catkin_ws/src
+  - wstool init
+  - if [[ -f $ROSINSTALL_FILE ]] ; then wstool merge $ROSINSTALL_FILE ; fi
+  - wstool up
+  # package depdencies: install using rosdep.
+  - cd ~/catkin_ws
+  - rosdep install -y --from-paths src --ignore-src --rosdistro $ROS_DISTRO
+
+# Compile and test (mark the build as failed if any step fails). If the
+# CATKIN_OPTIONS file exists, use it as an argument to catkin_make, for example
+# to blacklist certain packages.
+#
+# NOTE on testing: `catkin_make run_tests` will show the output of the tests
+# (gtest, nosetest, etc..) but always returns 0 (success) even if a test
+# fails. Running `catkin_test_results` aggregates all the results and returns
+# non-zero when a test fails (which notifies Travis the build failed).
 script:
-  - source /opt/ros/$CI_ROS_DISTRO/setup.bash
-  - mkdir -p $CATKIN_WS_SRC
-  - ln -s $TRAVIS_BUILD_DIR $CATKIN_WS_SRC
-  - cd $CATKIN_WS
-  # Build [and Install] packages, build tests, and run tests
-  - catkin_make_isolated --install --cmake-args -DCMAKE_BUILD_TYPE=Release &&
-    catkin_make_isolated --install --cmake-args -DCMAKE_BUILD_TYPE=Release --catkin-make-args tests &&
-    catkin_make_isolated --install --cmake-args -DCMAKE_BUILD_TYPE=Release --catkin-make-args run_tests
-  # Check results
-  - catkin_test_results ./build_isolated
+  - source /opt/ros/$ROS_DISTRO/setup.bash
+  - cd ~/catkin_ws
+  - catkin_make $( [ -f $CATKIN_OPTIONS ] && cat $CATKIN_OPTIONS )
+  # Run the tests, ensuring the path is set correctly.
+  - source devel/setup.bash
+  - catkin_make run_tests && catkin_test_results

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,6 @@ env:
 
 # Install system dependencies, namely a very barebones ROS setup.
 before_install:
-  - sudo apt-get install python-catkin-pkg
   - sudo sh -c "echo \"deb http://packages.ros.org/ros/ubuntu $ROS_CI_DESKTOP main\" > /etc/apt/sources.list.d/ros-latest.list"
   - wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
   - sudo apt-get update -qq

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
     - CI_ROS_DISTRO="indigo"
 before_install:
   - git clone https://github.com/StanleyInnovation/segway_v3
+  - git clone https://github.com/ros-planning/moveit.git
   - git clone https://github.com/Kinovarobotics/kinova-ros.git
 install:
   - sudo sh -c 'echo "deb http://packages.ros.org/ros-shadow-fixed/ubuntu trusty main" > /etc/apt/sources.list.d/ros-latest.list'
@@ -17,8 +18,6 @@ install:
   - sudo apt-get install -qq -y python-rosdep
   - sudo rosdep init
   - rosdep update
-  - sudo apt-get install ros-indigo-moveit-ros-planning-interface
-  - sudo apt-get install ros-indigo-moveit-ros-warehouse
   # Use rosdep to install all dependencies (including ROS itself)
   - rosdep install --from-paths .. --ignore-src --rosdistro $CI_ROS_DISTRO
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ env:
     - CI_ROS_DISTRO="indigo"
 before_install:
   - git clone https://github.com/StanleyInnovation/segway_v3
-  - git clone https://github.com/Kinovarobotics/kinova-ros.git
 install:
   - sudo sh -c 'echo "deb http://packages.ros.org/ros-shadow-fixed/ubuntu trusty main" > /etc/apt/sources.list.d/ros-latest.list'
   - wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
@@ -17,7 +16,6 @@ install:
   - sudo apt-get install -qq -y python-rosdep
   - sudo rosdep init
   - rosdep update
-  - sudo apt-get install ros-indigo-moveit-full
   # Use rosdep to install all dependencies (including ROS itself)
   - rosdep install --from-paths .. --ignore-src --rosdistro $CI_ROS_DISTRO
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ env:
   matrix:
     - CI_ROS_DISTRO="indigo"
 before_install:
-  - git clone https://github.com/StanleyInnovation/segway_v3_robot.git
   - git clone https://github.com/StanleyInnovation/segway_v3
   - git clone https://github.com/Kinovarobotics/kinova-ros.git
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ install:
   - sudo apt-get install -qq -y python-rosdep
   - sudo rosdep init
   - rosdep update
-  - sudo apt-get install ros-indigo-moveit-*
   # Use rosdep to install all dependencies (including ROS itself)
   - rosdep install --from-paths .. --ignore-src --rosdistro $CI_ROS_DISTRO
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,10 @@ install:
   - wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
   - sudo apt-get update -qq
   - sudo apt-get install -qq -y python-rosdep
-  - sudo apt-get install ros-$CI_ROS_DISTRO-agile-grasp
   - sudo rosdep init
   - rosdep update
   # Use rosdep to install all dependencies (including ROS itself)
-  - rosdep install --from-paths ./ -i -y --rosdistro $CI_ROS_DISTRO
+  - rosdep install --from-paths .. --ignore-src --rosdistro $CI_ROS_DISTRO
 script:
   - source /opt/ros/$CI_ROS_DISTRO/setup.bash
   - mkdir -p $CATKIN_WS_SRC

--- a/poli_description/CMakeLists.txt
+++ b/poli_description/CMakeLists.txt
@@ -1,10 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(poli_description)
 
-find_package(catkin REQUIRED COMPONENTS
-  roscpp
-  rospy
-)
+find_package(catkin REQUIRED)
 
 catkin_package(
 )

--- a/poli_launch/package.xml
+++ b/poli_launch/package.xml
@@ -14,8 +14,6 @@
   <run_depend>roscpp</run_depend>
   <run_depend>rospy</run_depend>
   <run_depend>segway_ros</run_depend>
-  <run_depend>kinova_bringup</run_depend>
-  <run_depend>kinova_description</run_depend>
 
 
   <export>

--- a/poli_launch/package.xml
+++ b/poli_launch/package.xml
@@ -14,9 +14,6 @@
   <run_depend>roscpp</run_depend>
   <run_depend>rospy</run_depend>
   <run_depend>segway_ros</run_depend>
-  <run_depend>segway_bringup</run_depend>
-  <run_depend>segway_navigation_apps</run_depend>
-  <run_depend>segway_description</run_depend>
   <run_depend>kinova_bringup</run_depend>
   <run_depend>kinova_description</run_depend>
 


### PR DESCRIPTION
Note: the main issue in configuring travis was that the default staging environment for travis changed. 
Reverting to an old environment configuration with `group: deprecated-2017Q3` was ultimately the solution.

Closes #1 