### PR TITLE
Dependencies specified in package.xml

### DIFF
--- a/dependencies.rosinstall
+++ b/dependencies.rosinstall
@@ -14,3 +14,20 @@
     local-name: kinova_ros
     uri: https://github.com/GT-RAIL/kinova-ros.git
     version: 7dof_kinetic
+- git:
+    local-name: wsg50-ros-pkg
+    uri: https://github.com/si-machines/wsg50-ros-pkg.git
+    version: kinetic_devel
+- git:
+    local-name: epos_hardware
+    uri: https://github.com/RIVeR-Lab/epos_hardware.git/
+    version: kinetic-devel
+- git:
+    local-name: dynamixel-workbench
+    uri: https://github.com/ROBOTIS-GIT/dynamixel-workbench.git
+    version: master
+- git:
+    local-name: dynamixel-workbench-msgs
+    uri: https://github.com/ROBOTIS-GIT/dynamixel-workbench-msgs.git
+    version: master
+

--- a/dependencies.rosinstall
+++ b/dependencies.rosinstall
@@ -30,4 +30,9 @@
     local-name: dynamixel-workbench-msgs
     uri: https://github.com/ROBOTIS-GIT/dynamixel-workbench-msgs.git
     version: master
+- git:
+    local-name: smart_battery_msgs
+    uri: https://github.com/ros-drivers/smart_battery_msgs.git
+    version: master
+
 

--- a/jaco2_custom_moveit_config/package.xml
+++ b/jaco2_custom_moveit_config/package.xml
@@ -22,6 +22,8 @@
   <run_depend>moveit_ros_visualization</run_depend>
   <run_depend>joint_state_publisher</run_depend>
   <run_depend>robot_state_publisher</run_depend>
+  <run_depend>trac_ik_kinematics_plugin</run_depend>
+  <run_depend>trac_ik</run_depend>
   <run_depend>xacro</run_depend>
   <!-- This package is referenced in the warehouse launch files, but does not build out of the box at the moment. Commented the dependency until this works. -->
   <!-- <run_depend>warehouse_ros_mongo</run_depend> -->

--- a/poli2_description/package.xml
+++ b/poli2_description/package.xml
@@ -13,9 +13,6 @@
   <build_depend>rospy</build_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>rospy</run_depend>
-  <run_depend>kinova_description</run_depend>
-  <run_depend>wsg_32_description</run_depend>
-
 
   <export>
   </export>

--- a/poli2_full_moveit/package.xml
+++ b/poli2_full_moveit/package.xml
@@ -22,6 +22,8 @@
   <run_depend>moveit_ros_visualization</run_depend>
   <run_depend>joint_state_publisher</run_depend>
   <run_depend>robot_state_publisher</run_depend>
+  <run_depend>trac_ik_kinematics_plugin</run_depend>
+  <run_depend>trac_ik</run_depend>
   <run_depend>xacro</run_depend>
   <!-- This package is referenced in the warehouse launch files, but does not build out of the box at the moment. Commented the dependency until this works. -->
   <!-- <run_depend>warehouse_ros_mongo</run_depend> -->

--- a/poli_launch/launch/base_bringup.aux.launch
+++ b/poli_launch/launch/base_bringup.aux.launch
@@ -19,7 +19,7 @@
   </node>
 
   <!-- launch the joint state publisher to default values -->
-  <node pkg="joint_state_publisher" type="joint_state_publisher" name="joint_state_publisher">
+  <node pkg="joint_state_publisher" type="joint_state_publisher" name="rmp_joint_state_publisher">
       <rosparam param="source_list">["/segway/rmp_joint_states", "/pillar/joint_states", "/wsg_50_driver/wsg/joint_states", "/j2s7s300_driver/out/joint_state", "/pan_motor/joint_state", "tilt_motor/joint_states"]</rosparam>
   </node>
 

--- a/poli_launch/package.xml
+++ b/poli_launch/package.xml
@@ -13,13 +13,10 @@
   
   <run_depend>roscpp</run_depend>
   <run_depend>rospy</run_depend>
-  <run_depend>epos_hardware</run_depend>
-  <run_depend>segway_ros</run_depend>
   <run_depend>ros_controllers</run_depend>
   <run_depend>ros_control</run_depend>
   <run_depend>robot_upstart</run_depend>
   <run_depend>yocs_cmd_vel_mux</run_depend>
-  <run_depend>ira_laser_tools</run_depend>
   <run_depend>range_sensor_layer</run_depend>
 
   <export>

--- a/poli_pan_tilt/CMakeLists.txt
+++ b/poli_pan_tilt/CMakeLists.txt
@@ -15,7 +15,7 @@ find_package(catkin REQUIRED COMPONENTS
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES poli_pan_tilt
-  CATKIN_DEPENDS roscpp rospy std_msgs dynamixel_workbench_msgs
+  CATKIN_DEPENDS roscpp rospy std_msgs dynamixel_workbench_msgs dynamixel_workbench_toolbox
 )
 
 include_directories(

--- a/poli_pan_tilt/package.xml
+++ b/poli_pan_tilt/package.xml
@@ -10,19 +10,17 @@
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>rospy</build_depend>
-  <build_depend>std_msgs</build_depend>
   <build_depend>dynamixel_workbench_msgs</build_depend>
   <build_depend>dynamixel_workbench_toolbox</build_depend>
+  <build_depend>std_msgs</build_depend>
   <build_depend>dynamixel_sdk</build_depend>
-  <build_depend>epos_hardware</build_depend>
   
   <run_depend>roscpp</run_depend>
   <run_depend>rospy</run_depend>
-  <run_depend>std_msgs</run_depend>
   <run_depend>dynamixel_workbench_msgs</run_depend>
   <run_depend>dynamixel_workbench_toolbox</run_depend>
+  <run_depend>std_msgs</run_depend>
   <run_depend>dynamixel_sdk</run_depend>
-  <run_depend>epos_hardware</run_depend>
 
   <export>
   </export>


### PR DESCRIPTION
This adds in previously unspecified dependent packages that can now be fetched using `rosdep`.

Other packages may have been removed since they do not have a rosdep entries and/or we expect a specific fork/branch combination. We fetch these using `wstool` and the .rosinstall file which has also been updated.