### PR TITLE
changed to fork for dynamixel package

### DIFF
--- a/dependencies.rosinstall
+++ b/dependencies.rosinstall
@@ -24,11 +24,11 @@
     version: kinetic-devel
 - git:
     local-name: dynamixel-workbench
-    uri: https://github.com/ROBOTIS-GIT/dynamixel-workbench.git
+    uri: https://github.com/si-machines/dynamixel-workbench.git
     version: master
 - git:
     local-name: dynamixel-workbench-msgs
-    uri: https://github.com/ROBOTIS-GIT/dynamixel-workbench-msgs.git
+    uri: https://github.com/si-machines/dynamixel-workbench-msgs.git
     version: master
 - git:
     local-name: smart_battery_msgs


### PR DESCRIPTION
Relieves ROBOTIS from upstream on dynamixel repositores in place of an si-machines organization fork.