### PR TITLE
**Not Ready** Automatically home tilt motor

### DIFF
--- a/poli_pan_tilt/scripts/launch_tilt_motor
+++ b/poli_pan_tilt/scripts/launch_tilt_motor
@@ -24,8 +24,9 @@ Author Maxwell Svetlik
 import rospy
 import roslaunch
 import rospkg
-from std_msgs.msg import Int16
+from std_msgs.msg import Int16, Float64
 from sensor_msgs.msg import JointState
+import time
 
 TOLERANCE = 0.005
 init_param = "/tilt_motor/encoders_initialized"
@@ -52,6 +53,7 @@ class LaunchTiltMotor(object):
         rospy.init_node('launch_tilt_motor', anonymous=True)
         rospy.Subscriber("/pillar/limit_switch", Int16, self.cb_limit_switch)
         rospy.Subscriber("/tilt_motor/joint_states", JointState, self.cb_joint_states)
+        self.tilt_pub   = rospy.Publisher('/tilt_motor/position_controller/command', Float64, queue_size=1)
 
         rospack = rospkg.RosPack()
         
@@ -73,6 +75,16 @@ class LaunchTiltMotor(object):
                     tilt_encoder = self.joint_states.position[0]
                     has_been_initialized = True
         
+        t_end = time.time() + 3 # Cut out auto initialization after 3 seconds
+        while time.time() < t_end:
+            if (self.joint_states.position[0] <= TOLERANCE and self.joint_states.position[0] >= -TOLERANCE and self.switch_pressed):
+                tilt_encoder = self.joint_states.position[0]
+                break
+            
+            msg = Float64()
+            msg.data = self.joint_states.position[0] + 0.03
+            self.tilt_pub.publish(msg)
+
         if rospy.is_shutdown():
             return
 


### PR DESCRIPTION
Fixes #56 

Initial attempt at automatically homing tilt motor.

This only works if the head was started at the lowest position and then moved. We need to edit the epos_hardware package directly to be able to set the homing position after start up.